### PR TITLE
Fix option default type for booleans

### DIFF
--- a/src/pydantic_avro/avro_to_pydantic.py
+++ b/src/pydantic_avro/avro_to_pydantic.py
@@ -82,6 +82,8 @@ def avsc_to_pydatic(schema: dict) -> str:
             default = field.get("default")
             if default is None:
                 current += f"    {n}: {t}\n"
+            elif isinstance(default, bool):
+                current += f"    {n}: {t} = {default}\n"
             else:
                 current += f"    {n}: {t} = {json.dumps(default)}\n"
         if len(schema["fields"]) == 0:

--- a/src/pydantic_avro/avro_to_pydantic.py
+++ b/src/pydantic_avro/avro_to_pydantic.py
@@ -2,7 +2,7 @@ import json
 from typing import Optional, Union
 
 
-def avsc_to_pydatic(schema: dict) -> str:
+def avsc_to_pydantic(schema: dict) -> str:
     """Generate python code of pydantic of given Avro Schema"""
     if "type" not in schema or schema["type"] != "record":
         raise AttributeError("Type not supported")
@@ -111,7 +111,7 @@ from pydantic import BaseModel
 def convert_file(avsc_path: str, output_path: Optional[str] = None):
     with open(avsc_path, "r") as fh:
         avsc_dict = json.load(fh)
-    file_content = avsc_to_pydatic(avsc_dict)
+    file_content = avsc_to_pydantic(avsc_dict)
     if output_path is None:
         print(file_content)
     else:

--- a/tests/test_from_avro.py
+++ b/tests/test_from_avro.py
@@ -178,6 +178,8 @@ def test_default():
                 {"name": "col1", "type": "string", "default": "test"},
                 {"name": "col2", "type": ["string", "null"], "default": None},
                 {"name": "col3", "type": {"type": "map", "values": "string"}, "default": {"key": "value"}},
+                {"name": "col4", "type": "boolean", "default": True},
+                {"name": "col5", "type": "boolean", "default": False},
             ],
         }
     )
@@ -185,5 +187,7 @@ def test_default():
         "class Test(BaseModel):\n"
         '    col1: str = "test"\n'
         "    col2: Optional[str] = None\n"
-        '    col3: Dict[str, str] = {"key": "value"}' in pydantic_code
+        '    col3: Dict[str, str] = {"key": "value"}\n'
+        "    col4: bool = True\n"
+        "    col5: bool = False\n" in pydantic_code
     )

--- a/tests/test_from_avro.py
+++ b/tests/test_from_avro.py
@@ -1,13 +1,13 @@
-from pydantic_avro.avro_to_pydantic import avsc_to_pydatic
+from pydantic_avro.avro_to_pydantic import avsc_to_pydantic
 
 
 def test_avsc_to_pydantic_empty():
-    pydantic_code = avsc_to_pydatic({"name": "Test", "type": "record", "fields": []})
+    pydantic_code = avsc_to_pydantic({"name": "Test", "type": "record", "fields": []})
     assert "class Test(BaseModel):\n    pass" in pydantic_code
 
 
 def test_avsc_to_pydantic_primitive():
-    pydantic_code = avsc_to_pydatic(
+    pydantic_code = avsc_to_pydantic(
         {
             "name": "Test",
             "type": "record",
@@ -33,7 +33,7 @@ def test_avsc_to_pydantic_primitive():
 
 
 def test_avsc_to_pydantic_map():
-    pydantic_code = avsc_to_pydatic(
+    pydantic_code = avsc_to_pydantic(
         {
             "name": "Test",
             "type": "record",
@@ -46,7 +46,7 @@ def test_avsc_to_pydantic_map():
 
 
 def test_avsc_to_pydantic_map_nested_object():
-    pydantic_code = avsc_to_pydatic(
+    pydantic_code = avsc_to_pydantic(
         {
             "name": "Test",
             "type": "record",
@@ -67,7 +67,7 @@ def test_avsc_to_pydantic_map_nested_object():
 
 
 def test_avsc_to_pydantic_map_nested_array():
-    pydantic_code = avsc_to_pydatic(
+    pydantic_code = avsc_to_pydantic(
         {
             "name": "Test",
             "type": "record",
@@ -90,7 +90,7 @@ def test_avsc_to_pydantic_map_nested_array():
 
 
 def test_avsc_to_pydantic_logical():
-    pydantic_code = avsc_to_pydatic(
+    pydantic_code = avsc_to_pydantic(
         {
             "name": "Test",
             "type": "record",
@@ -129,7 +129,7 @@ def test_avsc_to_pydantic_logical():
 
 
 def test_avsc_to_pydantic_complex():
-    pydantic_code = avsc_to_pydatic(
+    pydantic_code = avsc_to_pydantic(
         {
             "name": "Test",
             "type": "record",
@@ -170,7 +170,7 @@ def test_avsc_to_pydantic_complex():
 
 
 def test_default():
-    pydantic_code = avsc_to_pydatic(
+    pydantic_code = avsc_to_pydantic(
         {
             "name": "Test",
             "type": "record",


### PR DESCRIPTION
This pull-request does 2 things:

1. Add an if statement to check if default type is a boolean, if so correct Python type is output (line 85 and 86 in avro_to_pydantic.py). 
2. Fix a typo in function name (line 5 in avro_to_pydantic.py)