### PR TITLE
Add `by_alias` parameter to `avro_schema`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-avro"
-version = "0.3.2"
+version = "0.3.1"
 description = "Converting pydantic classes to avro schemas"
 authors = ["Peter van 't Hof' <peter.vanthof@godatadriven.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-avro"
-version = "0.3.1"
+version = "0.3.2"
 description = "Converting pydantic classes to avro schemas"
 authors = ["Peter van 't Hof' <peter.vanthof@godatadriven.com>"]
 

--- a/src/pydantic_avro/base.py
+++ b/src/pydantic_avro/base.py
@@ -7,9 +7,9 @@ class AvroBase(BaseModel):
     """This is base pydantic class that will add some methods"""
 
     @classmethod
-    def avro_schema(cls) -> dict:
+    def avro_schema(cls, by_alias: bool = True) -> dict:
         """Return the avro schema for the pydantic class"""
-        schema = cls.schema()
+        schema = cls.schema(by_alias=by_alias)
         return cls._avro_schema(schema)
 
     @staticmethod

--- a/src/pydantic_avro/base.py
+++ b/src/pydantic_avro/base.py
@@ -8,7 +8,12 @@ class AvroBase(BaseModel):
 
     @classmethod
     def avro_schema(cls, by_alias: bool = True) -> dict:
-        """Return the avro schema for the pydantic class"""
+        """
+        Return the avro schema for the pydantic class
+
+        :param by_alias: generate the schemas using the aliases defined, if any
+        :return: dict with the Avro Schema for the model
+        """
         schema = cls.schema(by_alias=by_alias)
         return cls._avro_schema(schema)
 

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from avro import schema as avro_schema
 from fastavro import parse_schema, reader, writer
+from pydantic import Field
 
 from pydantic_avro.base import AvroBase
 
@@ -66,6 +67,10 @@ class ReusedObjectArray(AvroBase):
 
 class DefaultValues(AvroBase):
     c1: str = "test"
+
+
+class ModelWithAliases(AvroBase):
+    field: str = Field(..., alias="Field")
 
 
 def test_avro():
@@ -254,3 +259,23 @@ def test_defaults():
     # Reading schema with avro library to be sure format is correct
     schema = avro_schema.parse(json.dumps(result))
     assert len(schema.fields) == 1
+
+
+def test_model_with_alias():
+    result = ModelWithAliases.avro_schema()
+    assert result == {
+        "type": "record",
+        "namespace": "ModelWithAliases",
+        "name": "ModelWithAliases",
+        "fields": [{"type": "string", "name": "Field"}],
+    }
+
+    result = ModelWithAliases.avro_schema(by_alias=False)
+    assert result == {
+        "type": "record",
+        "namespace": "ModelWithAliases",
+        "name": "ModelWithAliases",
+        "fields": [
+            {"type": "string", "name": "field"},
+        ],
+    }


### PR DESCRIPTION
So we can get a schema based on the fields of pydantic class as based on the aliases of fields.