### PR TITLE
Add support for array of arrays

### DIFF
--- a/src/pydantic_avro/base.py
+++ b/src/pydantic_avro/base.py
@@ -92,6 +92,14 @@ class AvroBase(BaseModel):
                     and tn.get("type", {}).get("logicalType") is not None
                 ):
                     tn = tn["type"]
+                # If items in array are an array, the structure must be corrected
+                if (
+                    isinstance(tn, dict)
+                    and isinstance(tn.get("type", {}), dict)
+                    and tn.get("type", {}).get("type") == "array"
+                ):
+                    items = tn["type"]["items"]
+                    tn = {"type": "array", "items": items}
                 avro_type_dict["type"] = {"type": "array", "items": tn}
             elif t == "string" and f == "date-time":
                 avro_type_dict["type"] = {

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -62,7 +62,6 @@ class ComplexTestModel(AvroBase):
     c4: List[datetime]
     c5: Dict[str, NestedModel]
     c6: Union[None, str, int, NestedModel]
-    c7: List[List[int]] = []
 
 
 class ReusedObject(AvroBase):

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -49,6 +49,12 @@ class TestModel(AvroBase):
     c14: bytes
 
 
+class ListofLists(AvroBase):
+    c1: int
+    c2: List[int]
+    c3: List[List[int]]
+
+
 class ComplexTestModel(AvroBase):
     c1: List[str]
     c2: NestedModel
@@ -56,6 +62,7 @@ class ComplexTestModel(AvroBase):
     c4: List[datetime]
     c5: Dict[str, NestedModel]
     c6: Union[None, str, int, NestedModel]
+    c7: List[List[int]] = []
 
 
 class ReusedObject(AvroBase):
@@ -240,6 +247,29 @@ def test_complex_avro():
     # Reading schema with avro library to be sure format is correct
     schema = avro_schema.parse(json.dumps(result))
     assert len(schema.fields) == 6
+
+
+def test_avro_parse_list_of_lists():
+    record = ListofLists(c1=1, c2=[2, 3], c3=[[4, 5], [6, 7]])
+
+    schema = ListofLists.avro_schema()
+    parsed_schema = parse_schema(schema)
+
+    records = [
+        record.dict(),
+    ]
+
+    with tempfile.TemporaryDirectory() as dir:
+        # Writing
+        with open(os.path.join(dir, "test.avro"), "wb") as out:
+            writer(out, parsed_schema, records)
+
+        result_records = []
+        # Reading
+        with open(os.path.join(dir, "test.avro"), "rb") as fo:
+            for record in reader(fo):
+                result_records.append(ListofLists.parse_obj(record))
+    assert records == result_records
 
 
 def test_avro_write_complex():


### PR DESCRIPTION
The structure for an array of arrays as it is currently rendered is not supported by `fastavro`. This PR fixes this nested structure such that pydantic models with list of lists can be parsed into an avro schema correctly.