### PR TITLE
Add basic record doc support

### DIFF
--- a/src/pydantic_avro/avro_to_pydantic.py
+++ b/src/pydantic_avro/avro_to_pydantic.py
@@ -87,6 +87,9 @@ def avsc_to_pydantic(schema: dict) -> str:
         """Convert a single avro record type to a pydantic class"""
         name = schema["name"]
         current = f"class {name}(BaseModel):\n"
+        doc = schema.get("doc")
+        if doc:
+            current += f'    """{doc}"""\n'
 
         for field in schema["fields"]:
             n = field["name"]

--- a/src/pydantic_avro/base.py
+++ b/src/pydantic_avro/base.py
@@ -184,4 +184,8 @@ class AvroBase(BaseModel):
 
         fields = get_fields(schema)
 
+        doc = schema.get("description")
+        if doc:
+            return {"type": "record", "namespace": namespace, "name": schema["title"], "doc": doc, "fields": fields}
+
         return {"type": "record", "namespace": namespace, "name": schema["title"], "fields": fields}

--- a/src/pydantic_avro/base.py
+++ b/src/pydantic_avro/base.py
@@ -184,8 +184,8 @@ class AvroBase(BaseModel):
 
         fields = get_fields(schema)
 
-        doc = schema.get("description")
-        if doc:
-            return {"type": "record", "namespace": namespace, "name": schema["title"], "doc": doc, "fields": fields}
+        output_avro_schema = {"type": "record", "namespace": namespace, "name": schema["title"], "fields": fields}
+        if cls.__doc__:
+            output_avro_schema["doc"] = schema["description"]
 
-        return {"type": "record", "namespace": namespace, "name": schema["title"], "fields": fields}
+        return output_avro_schema

--- a/src/pydantic_avro/base.py
+++ b/src/pydantic_avro/base.py
@@ -186,6 +186,9 @@ class AvroBase(BaseModel):
 
         output_avro_schema = {"type": "record", "namespace": namespace, "name": schema["title"], "fields": fields}
         if cls.__doc__:
-            output_avro_schema["doc"] = schema["description"]
+            doc = schema["description"]
+            # take only the main part of the docstring to avoid excessive doc length.
+            split = doc.find("\n\n")
+            output_avro_schema["doc"] = dic[:split] if split != -1 else doc
 
         return output_avro_schema

--- a/tests/test_from_avro.py
+++ b/tests/test_from_avro.py
@@ -280,3 +280,19 @@ def test_int():
     )
 
     assert "c1: int = Field(..., ge=-2**31, le=(2**31 - 1))" in pydantic_code
+
+def test_doc():
+    pydantic_code = avsc_to_pydantic(
+        {
+            "type": "record",
+            "name": "Test",
+            "doc": "docstring",
+            "fields": [
+                {
+                    "name": "c1",
+                    "type": "int",
+                },
+            ],
+        }
+    )
+    assert '"""docstring"""' in pydantic_code

--- a/tests/test_from_avro.py
+++ b/tests/test_from_avro.py
@@ -281,6 +281,7 @@ def test_int():
 
     assert "c1: int = Field(..., ge=-2**31, le=(2**31 - 1))" in pydantic_code
 
+
 def test_doc():
     pydantic_code = avsc_to_pydantic(
         {

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -460,3 +460,19 @@ def test_custom_name():
         "name": "some_other_name",
         "fields": [{"type": "long", "name": "c1"}],
     }
+
+
+class CustomDocModel(AvroBase):
+    """Custom Doc Model"""
+    c1: int
+
+
+def test_doc_description():
+    result = CustomDocModel.avro_schema()
+    assert result == {
+        "type": "record",
+        "namespace": "CustomDocModel"
+        "name": "CustomDocModel",
+        "doc": "Custom Doc Model",
+        "fields": [{"type": "int", "name": "c1"}]
+    }


### PR DESCRIPTION
This allows two different scenarios to work:
1) Pydantic Models with docstrings have their docstring converted to an Avro record `doc`.
2) Avro  records with `doc` get added as Pydantic Models' docstring.

Aka:

```
class Test(AvroBase):
    """docstring"""
    c1: int
```
Becomes
```
{
    "type": "record",
    "namespace": "Test"
    "name": "Test",
    "doc": "docstring",
    "fields": [{"type": "int", "name": "c1"}]
}
```
And visa-versa.