### PR TITLE
Fix issue with unsupported list values and tuple

### DIFF
--- a/src/pydantic_avro/base.py
+++ b/src/pydantic_avro/base.py
@@ -90,21 +90,12 @@ class AvroBase(BaseModel):
                 # If items in array are a object:
                 if "$ref" in items:
                     tn = tn["type"]
-                # If items in array are a logicalType
+                # Necessary to handle things like logical types, list of lists, and list with union
                 if (
                     isinstance(tn, dict)
-                    and isinstance(tn.get("type", {}), dict)
-                    and tn.get("type", {}).get("logicalType") is not None
+                    and isinstance(tn.get("type", None), (dict, list))
                 ):
                     tn = tn["type"]
-                # If items in array are an array, the structure must be corrected
-                if (
-                    isinstance(tn, dict)
-                    and isinstance(tn.get("type", {}), dict)
-                    and tn.get("type", {}).get("type") == "array"
-                ):
-                    items = tn["type"]["items"]
-                    tn = {"type": "array", "items": items}
                 avro_type_dict["type"] = {"type": "array", "items": tn}
             elif t == "string" and f == "date-time":
                 avro_type_dict["type"] = {

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -266,15 +266,16 @@ def test_complex_avro():
             {"name": "c4", "type": {"items": {"logicalType": "timestamp-micros", "type": "long"}, "type": "array"}},
             {"name": "c5", "type": {"type": "map", "values": "NestedModel"}},
             {"name": "c6", "type": ["null", "string", "long", "NestedModel"], "default": None},
-            {'name': 'c7',
-             'type': {
-                 'items': {
-                     'items': ['long', 'double'],
-                     'type': 'array'
-                 },
-                 'type': 'array'
+            {
+                'name': 'c7',
+                'type': {
+                    'items': {
+                        'items': ['long', 'double'],
+                        'type': 'array'
+                    },
+                    'type': 'array'
                 }
-             },
+            },
         ],
     }
 
@@ -362,6 +363,66 @@ def test_complex_nested_avro():
     # Reading schema with avro library to be sure format is correct
     schema = avro_schema.parse(json.dumps(result))
     assert len(schema.fields) == 1
+
+    # Also test parsing with fast avro
+    parse_schema(result)
+
+
+def test_tuple_avro():
+    result = TupleTestModel.avro_schema()
+    pprint(result)
+    assert result == {
+      "fields": [
+        {
+          "name": "c1",
+          "type": {
+            "items": ["long"],
+            "type": "array"
+          }
+        },
+        {
+          "name": "c2",
+          "type": {
+            "items": ["double"],
+            "type": "array"
+          }
+        },
+        {
+          "name": "c3",
+          "type": {
+            "items": [
+              {
+                "name": "Status",
+                "symbols": ["passed", "failed"],
+                "type": "enum"
+              },
+              "Status"
+            ],
+            "type": "array"
+          }
+        },
+        {
+          "name": "c4",
+          "type": {
+            "items": [
+              {
+                "type": "map",
+                "values": "string"
+              },
+              "Status"
+            ],
+            "type": "array"
+          }
+        }
+      ],
+      "name": "TupleTestModel",
+      "namespace": "TupleTestModel",
+      "type": "record"
+    }
+
+    # Reading schema with avro library to be sure format is correct
+    schema = avro_schema.parse(json.dumps(result))
+    assert len(schema.fields) == 4
 
     # Also test parsing with fast avro
     parse_schema(result)
@@ -539,7 +600,7 @@ def test_optional_array():
 
 
 class IntModel(AvroBase):
-    c1: int = Field(..., ge=-(2**31), le=(2**31 - 1))
+    c1: int = Field(..., ge=-(2 ** 31), le=(2 ** 31 - 1))
 
 
 def test_int():

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -65,9 +65,9 @@ class ListofLists(AvroBase):
     c3: List[List[int]]
 
 
-AllBasicTypes = str | int | float | bool | None
-LeafForNestedType = list[AllBasicTypes] | dict[str, AllBasicTypes]
-RootNestedType = dict[str, AllBasicTypes | LeafForNestedType] | list[AllBasicTypes | LeafForNestedType]
+AllBasicTypes = Union[str, int, float, bool, None]
+LeafForNestedType = Union[list[AllBasicTypes], Dict[str, AllBasicTypes]]
+RootNestedType = Union[Dict[str, Union[AllBasicTypes, LeafForNestedType]], list[Union[AllBasicTypes, LeafForNestedType]]]
 
 
 class ComplexNestedTestModel(AvroBase):
@@ -75,10 +75,10 @@ class ComplexNestedTestModel(AvroBase):
 
 
 class TupleTestModel(AvroBase):
-    c1: tuple[int]
-    c2: tuple[float, float]
-    c3: tuple[Status, Status]
-    c4: tuple[dict[str, str] | Status]
+    c1: Tuple[int]
+    c2: Tuple[float, float]
+    c3: Tuple[Status, Status]
+    c4: Tuple[Union[Dict[str, str], Status]]
 
 
 class ComplexTestModel(AvroBase):

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -66,8 +66,8 @@ class ListofLists(AvroBase):
 
 
 AllBasicTypes = Union[str, int, float, bool, None]
-LeafForNestedType = Union[list[AllBasicTypes], Dict[str, AllBasicTypes]]
-RootNestedType = Union[Dict[str, Union[AllBasicTypes, LeafForNestedType]], list[Union[AllBasicTypes, LeafForNestedType]]]
+LeafForNestedType = Union[List[AllBasicTypes], Dict[str, AllBasicTypes]]
+RootNestedType = Union[Dict[str, Union[AllBasicTypes, LeafForNestedType]], List[Union[AllBasicTypes, LeafForNestedType]]]
 
 
 class ComplexNestedTestModel(AvroBase):

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -5,7 +5,7 @@ import tempfile
 import uuid
 from datetime import date, datetime, time, timezone
 from pprint import pprint
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Type, Union, Tuple
 from uuid import UUID
 
 from avro import schema as avro_schema
@@ -74,6 +74,13 @@ class ComplexNestedTestModel(AvroBase):
     c1: RootNestedType
 
 
+class TupleTestModel(AvroBase):
+    c1: tuple[int]
+    c2: tuple[float, float]
+    c3: tuple[Status, Status]
+    c4: tuple[dict[str, str] | Status]
+
+
 class ComplexTestModel(AvroBase):
     c1: List[str]
     c2: NestedModel
@@ -81,6 +88,7 @@ class ComplexTestModel(AvroBase):
     c4: List[datetime]
     c5: Dict[str, NestedModel]
     c6: Union[None, str, int, NestedModel] = None
+    c7: List[Tuple[Union[int, float], Union[int, float]]]
 
 
 class ReusedObject(AvroBase):
@@ -258,12 +266,21 @@ def test_complex_avro():
             {"name": "c4", "type": {"items": {"logicalType": "timestamp-micros", "type": "long"}, "type": "array"}},
             {"name": "c5", "type": {"type": "map", "values": "NestedModel"}},
             {"name": "c6", "type": ["null", "string", "long", "NestedModel"], "default": None},
+            {'name': 'c7',
+             'type': {
+                 'items': {
+                     'items': ['long', 'double'],
+                     'type': 'array'
+                 },
+                 'type': 'array'
+                }
+             },
         ],
     }
 
     # Reading schema with avro library to be sure format is correct
     schema = avro_schema.parse(json.dumps(result))
-    assert len(schema.fields) == 6
+    assert len(schema.fields) == 7
 
 
 def test_complex_nested_avro():
@@ -378,6 +395,7 @@ def test_avro_write_complex():
         c3=[NestedModel(c11=Nested2Model(c111="test"))],
         c4=[1, 2, 3, 4],
         c5={"key": NestedModel(c11=Nested2Model(c111="test"))},
+        c7=[(1.0, 1)]
     )
 
     parsed_schema = parse_schema(ComplexTestModel.avro_schema())

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -65,6 +65,15 @@ class ListofLists(AvroBase):
     c3: List[List[int]]
 
 
+AllBasicTypes = str | int | float | bool | None
+LeafForNestedType = list[AllBasicTypes] | dict[str, AllBasicTypes]
+RootNestedType = dict[str, AllBasicTypes | LeafForNestedType] | list[AllBasicTypes | LeafForNestedType]
+
+
+class ComplexNestedTestModel(AvroBase):
+    c1: RootNestedType
+
+
 class ComplexTestModel(AvroBase):
     c1: List[str]
     c2: NestedModel
@@ -255,6 +264,91 @@ def test_complex_avro():
     # Reading schema with avro library to be sure format is correct
     schema = avro_schema.parse(json.dumps(result))
     assert len(schema.fields) == 6
+
+
+def test_complex_nested_avro():
+    result = ComplexNestedTestModel.avro_schema()
+    pprint(result)
+    assert result == {
+        'type': 'record',
+        'name': 'ComplexNestedTestModel',
+        'namespace': 'ComplexNestedTestModel',
+        'fields': [
+            {
+                'name': 'c1',
+                'type': [
+                    {
+                        'type': 'map',
+                        'values': [
+                            'string',
+                            'long',
+                            'double',
+                            'boolean',
+                            {
+                                'items': [
+                                    'string',
+                                    'long',
+                                    'double',
+                                    'boolean',
+                                    'null'
+                                ],
+                                'type': 'array'
+                            },
+                            {
+                                'type': 'map',
+                                'values': [
+                                    'string',
+                                    'long',
+                                    'double',
+                                    'boolean',
+                                    'null'
+                                ]
+                            },
+                            'null'
+                        ]
+                    },
+                    {
+                        'items': [
+                            'string',
+                            'long',
+                            'double',
+                            'boolean',
+                            {
+                                'items': [
+                                    'string',
+                                    'long',
+                                    'double',
+                                    'boolean',
+                                    'null'
+                                ],
+                                'type': 'array'
+                            },
+                            {
+                                'type': 'map',
+                                'values': [
+                                    'string',
+                                    'long',
+                                    'double',
+                                    'boolean',
+                                    'null'
+                                ]
+                            },
+                            'null'
+                        ],
+                        'type': 'array'
+                    }
+                ]
+            },
+        ]
+    }
+
+    # Reading schema with avro library to be sure format is correct
+    schema = avro_schema.parse(json.dumps(result))
+    assert len(schema.fields) == 1
+
+    # Also test parsing with fast avro
+    parse_schema(result)
+
 
 
 def test_avro_parse_list_of_lists():

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -350,7 +350,6 @@ def test_complex_nested_avro():
     parse_schema(result)
 
 
-
 def test_avro_parse_list_of_lists():
     record1 = ListofLists(c1=1, c2=[2, 3], c3=[[4, 5], [6, 7]])
 


### PR DESCRIPTION
In this PR, I am fixing two issues when going from pydantic to avro.

The first issue is for pydantic fields that are a list with certain value types like `list[str | None]` or `list[dict[str, str]]`.  This fixes one of the issues currently posted ([this issue](https://github.com/godatadriven/pydantic-avro/issues/96)), but it fixes more than just nullable elements in an array.  We also saw an issue with certain `dict`s as the value for an array.  For the issues with a `dict`, we were getting, `TypeError: unhashable type: 'dict'` when we tried to parse the schema.

In debugging the issue, it seemed like several of the cases in the `get_type` for when `t == "array"` could be simplified to just inline the `type` from the dictionary that represents the types of the elements.

The second issue fixed in this PR is adding support for `tuple` (referenced in [this issue](https://github.com/godatadriven/pydantic-avro/issues/97)).  The JSON schema that pydantic generates for `tuple` looks like this:

Example class:
```
class TupleTestModel(AvroBase):
    c1: tuple[int]    
```

Generated JSON schema from pydantic:
```
{
  "properties": {
    "c1": {
      "maxItems": 1,
      "minItems": 1,
      "prefixItems": [
        {
          "type": "integer"
        }
      ],
      "title": "C1",
      "type": "array"
    }
  },
  "required": ["c1"],
  "title": "TupleTestModel",
  "type": "object"
}
```
A tuple is an array, but it uses the [prefixItems](https://json-schema.org/understanding-json-schema/reference/array#tupleValidation) to define that.  Previously we would fall into the array case within `get_type` and blow up because there are no `items`.  In this MR, I am adding a special case to check for `prefixItems` and handle that.

Test cases were added for both the new handling with `list` and `tuple`.  All existing tests pass.