### PR TITLE
Fix: AttributeError: 'list' object has no attribute 'get'

### DIFF
--- a/src/pydantic_avro/from_avro/types.py
+++ b/src/pydantic_avro/from_avro/types.py
@@ -132,7 +132,7 @@ def generate_field_string(field: dict) -> str:
 
 def get_pydantic_type(t: Union[str, dict]) -> str:
     """Get the Pydantic type for a given Avro type"""
-    if isinstance(t, str):
+    if isinstance(t, str) or isinstance(t, list):
         t = {"type": t}
 
     if isinstance(t.get("type"), str):

--- a/tests/test_from_avro.py
+++ b/tests/test_from_avro.py
@@ -146,6 +146,79 @@ def test_avsc_to_pydantic_optional_map_primitive_value():
     assert 'col1: Optional[Dict[str, string]] = "null"' in pydantic_code
 
 
+def test_avsc_to_pydantic_optional_list_with_optional_records():
+    pydantic_code = avsc_to_pydantic(
+        {
+            "name": "PyScGenClass",
+            "type": "record",
+            "fields": [
+                {
+                    "name": "document_list",
+                    "type": [
+                        "null",
+                        {
+                            "type": "array",
+                            "items": [
+                                "null",
+                                {
+                                    "name": "document_list_record",
+                                    "type": "record",
+                                    "fields": [
+                                        {
+                                            "name": "float",
+                                            "type": [
+                                                "null",
+                                                "float"
+                                            ]
+                                        },
+                                        {
+                                            "name": "int",
+                                            "type": [
+                                                "null",
+                                                "int"
+                                            ]
+                                        },
+                                        {
+                                            "name": "string",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+    assert 'document_list: Optional[List[Optional[document_list_record]]]' in pydantic_code
+
+
+def test_avsc_to_pydantic_map_with_union_types_and_list_of_values():
+    pydantic_code = avsc_to_pydantic(
+       {
+          "namespace": "com.example",
+          "type": "record",
+          "name": "TestEvent",
+          "fields": [
+            {
+              "name": "event_data",
+              "type": {
+                "type": "map",
+                "values": ["null", "string"]
+              },
+              "default": {}
+            }
+          ]
+        }
+    )
+    print(pydantic_code)
+    assert 'event_data: Dict[str, Optional[str]] = {}' in pydantic_code
+
+
 def test_avsc_to_pydantic_logical():
     pydantic_code = avsc_to_pydantic(
         {


### PR DESCRIPTION
I was exploring another project (https://github.com/Salfiii/pyscgen) and while updating it and its dependencies I noticed that in one test this library throws an exception. When looking at issue list I noticed this one: https://github.com/godatadriven/pydantic-avro/issues/146 which reported the same exception but for another case. So i experimented a bit, tried to understand some code here and made this PR as it seem to fix both issues (covered with tests).

I hope you find those changes good enough for your repo or at least take those as inspiration for proper fix. Thanks in advance!

Best Regards,
Bart