### PR TITLE
fix(to_avro): fall back to Avro string for unmapped JSON-Schema string formats

### DIFF
--- a/src/pydantic_avro/to_avro/types.py
+++ b/src/pydantic_avro/to_avro/types.py
@@ -219,7 +219,11 @@ class AvroTypeConverter:
         """Returns a type of a string field"""
         if not f:
             return "string"
-        return STRING_TYPE_MAPPING[f]
+        # Avro has no dedicated type for many JSON-Schema string formats that
+        # Pydantic emits (e.g. "email", "uri", "ipvanyaddress" from EmailStr,
+        # AnyUrl, IPvAnyAddress). Fall back to a plain Avro "string" for any
+        # unmapped format instead of raising a KeyError.
+        return STRING_TYPE_MAPPING.get(f, "string")
 
     @staticmethod
     def _integer_to_avro(field_props: dict) -> str:

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from avro import schema as avro_schema
 from fastavro import parse_schema, reader, writer
-from pydantic import Field
+from pydantic import AnyUrl, Field, IPvAnyAddress
 
 from pydantic_avro.base import AvroBase
 from pydantic_avro.to_avro.config import PYDANTIC_V2
@@ -754,3 +754,22 @@ def test_union_with_avro_type():
         for t in field_types
     )
     assert has_timestamp_millis
+
+
+class StringFormatModel(AvroBase):
+    # Pydantic emits string "format"s that Avro has no dedicated type for:
+    #   AnyUrl -> "uri", IPvAnyAddress -> "ipvanyaddress" (EmailStr -> "email").
+    url: AnyUrl
+    ip: IPvAnyAddress
+
+
+def test_unmapped_string_format_falls_back_to_string():
+    # Regression: previously these raised KeyError (e.g. KeyError: 'uri') because
+    # an unmapped JSON-Schema string "format" indexed STRING_TYPE_MAPPING directly.
+    # Such formats must degrade to a plain Avro "string".
+    result = StringFormatModel.avro_schema()
+    field_types = {f["name"]: f["type"] for f in result["fields"]}
+    assert field_types["url"] == "string"
+    assert field_types["ip"] == "string"
+    # The produced schema must still be valid Avro.
+    parse_schema(result)


### PR DESCRIPTION
## Problem

`AvroBase.avro_schema()` raises a raw `KeyError` for Pydantic string fields whose
JSON-Schema `format` is not present in `STRING_TYPE_MAPPING`. This hits several
common Pydantic types:

```python
from pydantic_avro.base import AvroBase
from pydantic import AnyUrl, EmailStr, IPvAnyAddress

class M(AvroBase):
    url: AnyUrl          # format "uri"           -> KeyError: 'uri'
    email: EmailStr      # format "email"         -> KeyError: 'email'
    ip: IPvAnyAddress    # format "ipvanyaddress" -> KeyError: 'ipvanyaddress'

M.avro_schema()  # 💥 KeyError
```

`AvroTypeConverter._string_to_avro()` indexed the mapping directly
(`STRING_TYPE_MAPPING[f]`), so any format the library doesn't explicitly map
crashes instead of producing a schema.

## Fix

Avro has no dedicated type for `uri`/`email`/`ipvanyaddress`/etc. — they are all
just strings — so degrade any **unmapped** format to a plain Avro `"string"`:

```python
return STRING_TYPE_MAPPING.get(f, "string")
```

Mapped formats (`date-time`, `date`, `time`, `uuid`, `binary`) are unchanged.

## Tests

Added `test_unmapped_string_format_falls_back_to_string` (uses `AnyUrl` /
`IPvAnyAddress`, no extra deps) asserting the fields become Avro `"string"` and
the produced schema parses with `fastavro`. Full suite passes (48 tests).
