### PR TITLE
Automate dependency updates and modernize release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,23 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,8 +1,6 @@
 name: Build and Publish
 on:
   workflow_dispatch: # Only manual trigger and only for the main branch
-    branches:
-    - main
     inputs:
       bump_level:
         type: choice
@@ -18,56 +16,56 @@ permissions:
 
 jobs:
   build-and-publish:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: release       # required for PyPI trusted publishing (OIDC)
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
-        token: ${{ secrets.GIT_TOKEN_DANIEL }}
+        token: ${{ secrets.GIT_TOKEN_DANIEL }}  # needed to push the bump commit to protected main
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.12"
 
-    - name: Install dependencies
+    - name: Install Poetry
+      run: curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
+
+    - name: Bump version, tag and push
       run: |
-        curl -sSL https://install.python-poetry.org | python3 - --version 1.2.2
+        set -eu
+        BUMP_LEVEL='${{ github.event.inputs.bump_level }}'
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
 
-    - name: Build and publish
-      run: |
-        set -euv
-        
-        BUMP_LEVEL=${{ github.event.inputs.bump_level }}
-        echo "bump level: ${BUMP_LEVEL}"
-        git config --local user.email "Bumpversion"
-        git config --local user.name "Bumpversion"
-
-        # Version bump
-
-        NEW_VERSION=$(poetry version -s ${BUMP_LEVEL})
-        echo ${NEW_VERSION}
-        git add pyproject.toml poetry.lock
+        NEW_VERSION=$(poetry version -s "${BUMP_LEVEL}")
+        echo "New version: ${NEW_VERSION}"
+        git add pyproject.toml
         git commit -m "Bump version to ${NEW_VERSION}"
         git tag "v${NEW_VERSION}"
 
-        git push -f  
-        git push --tags -f
-        
-        poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-        poetry publish --build
-        
+        git push origin HEAD:main
+        git push origin "v${NEW_VERSION}"
+
         echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
 
-    - name: Create Release
-      uses: actions/create-release@v1
+    - name: Build distributions
+      run: poetry build
+
+    - name: Publish to PyPI (trusted publishing)
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Create GitHub Release with generated notes
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: v${{ env.NEW_VERSION }}
-        release_name: v${{ env.NEW_VERSION }}
-        body: |
-          pypi package: https://pypi.org/project/pydantic-avro/${{ env.NEW_VERSION }}/
-        draft: false
-        prerelease: false
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "v${NEW_VERSION}" \
+          --title "v${NEW_VERSION}" \
+          --generate-notes \
+          --notes "PyPI package: https://pypi.org/project/pydantic-avro/${NEW_VERSION}/"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,10 +18,8 @@ jobs:
   build-and-publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: release       # required for PyPI trusted publishing (OIDC)
     permissions:
       contents: write
-      id-token: write
 
     steps:
     - name: Checkout
@@ -58,8 +56,12 @@ jobs:
     - name: Build distributions
       run: poetry build
 
-    - name: Publish to PyPI (trusted publishing)
+    # TODO: switch to trusted publishing (OIDC) once a project owner on PyPI
+    # can add a trusted publisher for this repo
+    - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}
 
     - name: Create GitHub Release with generated notes
       env:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

- **Dependabot**: weekly cadence, minor+patch updates grouped into a single PR, and a new `github-actions` ecosystem entry so our (currently ancient, e.g. `checkout@v2`, deprecated `create-release@v1`) actions get update PRs too.
- **Auto-merge**: new workflow that approves and enables auto-merge (squash) for non-major Dependabot PRs. Merges only happen once the required branch-protection checks pass (the full test matrix is now required). Major bumps still require a human.
- **Release workflow modernized** (same manual `workflow_dispatch` + bump-level UX as before):
  - no more `git push -f` to main
  - `checkout@v4` / `setup-python@v5`, Poetry 1.8.3
  - GitHub release now gets **auto-generated release notes** from merged PRs instead of a static body
  - publishing still uses `PYPI_TOKEN` for now; switching to trusted publishing (OIDC) is a follow-up once PyPI project ownership is sorted out