### PR TITLE
fix(to_avro): order optional unions so the default's type comes first

### DIFF
--- a/src/pydantic_avro/to_avro/types.py
+++ b/src/pydantic_avro/to_avro/types.py
@@ -85,11 +85,50 @@ def set_nullability(avro_type_dict: dict) -> dict:
     return avro_type_dict
 
 
-def null_to_first_element(avro_type_dict: dict) -> dict:
-    """Set the null as the first element in the list as per avro schema requirements"""
-    if type(avro_type_dict["type"]) is list and "null" in avro_type_dict["type"]:
-        avro_type_dict["type"].remove("null")
-        avro_type_dict["type"].insert(0, "null")
+# Python type of a field default -> Avro base types whose union branch may carry that default.
+# ``bool`` is listed before ``int`` because it is an ``int`` subclass.
+_DEFAULT_TYPE_CANDIDATES = (
+    (bool, ("boolean",)),
+    (int, ("long", "int")),
+    (float, ("double", "float")),
+    (str, ("string", "enum")),
+    (bytes, ("bytes",)),
+    (list, ("array",)),
+    (dict, ("record", "map")),
+)
+
+
+def _branch_base_type(branch: Any) -> Optional[str]:
+    """Base Avro type of a union branch: ``"long"`` for both ``"long"`` and ``{"type": "long", "logicalType": ...}``."""
+    if isinstance(branch, str):
+        return branch
+    if isinstance(branch, dict) and isinstance(branch.get("type"), str):
+        return branch["type"]
+    return None
+
+
+def order_union_for_default(avro_type_dict: dict) -> dict:
+    """Order a union so that its first branch matches the field default, as the Avro spec requires.
+
+    A default of ``None`` keeps ``null`` first. Any other default moves ``null`` last and, when the
+    default's Python type identifies one of the remaining branches, promotes that branch to the front.
+    """
+    union = avro_type_dict.get("type")
+    if type(union) is not list or "null" not in union:
+        return avro_type_dict
+    union.remove("null")
+    default = avro_type_dict.get("default")
+    if default is None:
+        union.insert(0, "null")
+        return avro_type_dict
+    union.append("null")
+    for py_type, avro_names in _DEFAULT_TYPE_CANDIDATES:
+        if isinstance(default, py_type):
+            for i, branch in enumerate(union):
+                if _branch_base_type(branch) in avro_names:
+                    union.insert(0, union.pop(i))
+                    break
+            break
     return avro_type_dict
 
 
@@ -113,7 +152,7 @@ class AvroTypeConverter:
             avro_type_dict["name"] = name
             if name not in required:
                 set_nullability(avro_type_dict)
-                avro_type_dict = null_to_first_element(avro_type_dict)
+                avro_type_dict = order_union_for_default(avro_type_dict)
 
             fields.append(avro_type_dict)
         return fields

--- a/tests/test_to_avro.py
+++ b/tests/test_to_avro.py
@@ -338,7 +338,7 @@ def test_avro_write_complex():
 
 def test_defaults():
     # Pydantic v1 wrongly omit null type from optional field with non-None default
-    c3_type = ["null", "string"] if PYDANTIC_V2 else "string"
+    c3_type = ["string", "null"] if PYDANTIC_V2 else "string"
 
     result = DefaultValues.avro_schema()
     assert result == {
@@ -773,3 +773,41 @@ def test_unmapped_string_format_falls_back_to_string():
     assert field_types["ip"] == "string"
     # The produced schema must still be valid Avro.
     parse_schema(result)
+
+
+class OptionalWithNonNullDefault(AvroBase):
+    c1: Optional[int] = 0
+    c2: Optional[str] = "x"
+    c3: Optional[bool] = False
+    c4: Optional[float] = 1.5
+    c5: Optional[str] = None
+
+
+def test_optional_with_non_null_default_puts_matching_type_first():
+    """Regression for #161: Avro requires the default's type to be the first union branch,
+    so ``null`` may only lead the union when the default is ``None``."""
+    fields = {f["name"]: f for f in OptionalWithNonNullDefault.avro_schema()["fields"]}
+    if PYDANTIC_V2:
+        assert fields["c1"] == {"name": "c1", "type": ["long", "null"], "default": 0}
+        assert fields["c2"] == {"name": "c2", "type": ["string", "null"], "default": "x"}
+        assert fields["c3"] == {"name": "c3", "type": ["boolean", "null"], "default": False}
+        assert fields["c4"] == {"name": "c4", "type": ["double", "null"], "default": 1.5}
+    else:
+        # pydantic v1 drops ``null`` from Optional[...] fields that carry a default; unchanged behaviour
+        assert fields["c1"] == {"name": "c1", "type": "long", "default": 0}
+    assert fields["c5"] == {"name": "c5", "type": ["null", "string"], "default": None}
+
+
+class UnionWithNonNullDefault(AvroBase):
+    c1: Union[int, str, None] = "a"
+    c2: Union[None, int, str] = 3
+
+
+def test_union_with_non_null_default_promotes_matching_branch():
+    """Regression for #161: with several non-null branches the one matching the default leads,
+    and ``null`` goes last."""
+    if not PYDANTIC_V2:
+        return  # pydantic v1 emits no anyOf for Union fields
+    fields = {f["name"]: f for f in UnionWithNonNullDefault.avro_schema()["fields"]}
+    assert fields["c1"] == {"name": "c1", "type": ["string", "long", "null"], "default": "a"}
+    assert fields["c2"] == {"name": "c2", "type": ["long", "string", "null"], "default": 3}


### PR DESCRIPTION
Fixes #161.

Avro requires a union field's default to match the **first** branch of the union. `null_to_first_element` always moved `null` to the front, so every non-required `Optional[...]` field with a non-null default produced a schema that Java's `Schema.Parser` (and therefore Confluent Schema Registry) rejects with *Invalid default*. Neither `fastavro` nor `avro`'s Python parser validate this, which is why the suite never caught it.

```python
class Test(AvroBase):
    id: None | int = 0
# before: {"type": ["null", "long"], "default": 0}   <- invalid
# after:  {"type": ["long", "null"], "default": 0}
```

**Change**: `order_union_for_default` replaces `null_to_first_element`. A default of `None` keeps `null` first (unchanged behaviour). Any other default moves `null` last and, when the union has several non-null branches, promotes the branch matching the default's Python type (`Union[int, str, None] = "a"` -> `["string", "long", "null"]`), as @ViktorZak pointed out in the issue.

**Tests**: new regression tests for Optional int/str/bool/float defaults, the multi-branch case, and the default-None regression; `test_defaults` updated (it encoded the invalid order). Full suite green locally under pydantic 2.13.5 and 1.10.26.