### PR TITLE
ci: test on Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         pydantic-version: ["pydantic-v1", "pydantic-v2"]
 
     steps:


### PR DESCRIPTION
Extends the test matrix from 3.11/3.12 to 3.11–3.14 (both pydantic-v1 and pydantic-v2 axes). 3.15 is still in release candidate and is left out. If the new jobs pass they become required checks on main.